### PR TITLE
Revert "Use null instead of empty string for dynamic optional value defaults"

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,9 +3,9 @@ data "aws_region" "current" {} # auto-populated
 locals {
   fqdn = "${var.subdomain_name}.${data.aws_route53_zone.current.name}"
   # Variable defaults cannot be directly based on other variables
-  heroku_app_name           = var.heroku_app_name != null ? var.heroku_app_name : var.project_slug
-  storage_bucket_name       = var.storage_bucket_name != null ? var.storage_bucket_name : "${var.project_slug}-storage"
-  django_default_from_email = var.django_default_from_email != null ? var.django_default_from_email : "admin@${local.fqdn}"
+  heroku_app_name           = var.heroku_app_name != "" ? var.heroku_app_name : var.project_slug
+  storage_bucket_name       = var.storage_bucket_name != "" ? var.storage_bucket_name : "${var.project_slug}-storage"
+  django_default_from_email = var.django_default_from_email != "" ? var.django_default_from_email : "admin@${local.fqdn}"
 }
 
 data "aws_route53_zone" "current" {

--- a/variables.tf
+++ b/variables.tf
@@ -22,19 +22,19 @@ variable "route53_zone_id" {
 # Optional variables
 variable "heroku_app_name" {
   type        = string
-  default     = null # Actual default is set internally
+  default     = "" # Actual default is set internally
   description = "The name of the Heroku app."
 }
 
 variable "storage_bucket_name" {
   type        = string
-  default     = null # Actual default is set internally
+  default     = "" # Actual default is set internally
   description = "The globally unique S3 bucket name of the storage."
 }
 
 variable "django_default_from_email" {
   type        = string
-  default     = null # Actual default is set internally
+  default     = "" # Actual default is set internally
   description = "The default email address which Django will send from."
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -105,7 +105,7 @@ variable "heroku_papertrail_plan" {
 
 variable "ec2_worker_ssh_public_key" {
   type        = string
-  default     = null
+  default     = ""
   description = "An SSH public key, to be installed on the EC2 workers. This must be set if ec2_worker_instance_quantity > 0."
 }
 


### PR DESCRIPTION
This causes Terraform Registry to mark these as required.