### PR TITLE
Disable nightly CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - master
-  schedule:
-    - cron: "0 0 * * *"
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
It's very unlikely that this will catch new errors, and this repo is not updated frequently enough to keep GitHub from disabling the Action.